### PR TITLE
notistack already supports passing a node for a message like the mate…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ export type CombinedClassKey = NotistackClassKey | SnackbarClassKey;
 
 export interface InjectedNotistackProps {
     onPresentSnackbar: (variant: VariantType, message: string) => void;
-    enqueueSnackbar: (message: string, options?: OptionsObject) => void;
+    enqueueSnackbar: (message: string | React.ReactNode, options?: OptionsObject) => void;
 }
 
 export function withSnackbar<P extends InjectedNotistackProps>(component: React.ComponentType<P>):


### PR DESCRIPTION
…rail-ui Snackbar does. However, the type definition needs to be updated to allow for this in a strictly-typed TS project.